### PR TITLE
Removed svc macro

### DIFF
--- a/patches/emunand/patches.s
+++ b/patches/emunand/patches.s
@@ -1,4 +1,4 @@
-.nds
+.arm.little
 
 #!variables
 

--- a/patches/reboot/patches.s
+++ b/patches/reboot/patches.s
@@ -1,15 +1,4 @@
-.nds
-
-.macro svc, num
-	.if isArm()
-		.word 0xEF000000 | num
-	.else
-		.if num > 0xFF
-			.error "bitch you crazu"
-		.endif
-		.halfword 0xDF00 | num
-	.endif
-.endmacro
+.arm.little
 
 #!variables
 
@@ -43,9 +32,9 @@ patch005:
 	mov r3, r2
 	mov r1, r2
 	mov r0, r2
-	svc 0x7C
+	swi 0x7C
 	ldr r0, =0x80FF4FC
-	svc 0x7B
+	swi 0x7B
 
 @@inf_loop:
 	b @@inf_loop

--- a/patches/signatures/patches.s
+++ b/patches/signatures/patches.s
@@ -1,4 +1,4 @@
-.nds
+.arm.little
 
 .create "patch1.bin"
 .thumb

--- a/patches/slot0x25keyX/patches.s
+++ b/patches/slot0x25keyX/patches.s
@@ -1,4 +1,4 @@
-.nds
+.arm.little
 
 #!variables
 


### PR DESCRIPTION
This uses armips' "swi" call which is equivalent.

.nds directives have been replaced with .arm.little because "swi" used a different convention and interrupt value was being shifted left by 16 bits.

That shift is actually the only difference between ".nds" and ".arm.little". Generated patches match 1:1 the old ones.

This should allow compilation with older versions of armips that lacked the `.if isArm()` construction as well (#20).
