### PR TITLE
Silenced debug output option

### DIFF
--- a/source/config.c
+++ b/source/config.c
@@ -9,7 +9,7 @@
 #include "fcram.h"
 #include "paths.h"
 
-static unsigned int config_ver = 3;
+static unsigned int config_ver = 4;
 
 struct config_file *config = (struct config_file *)FCRAM_CONFIG;
 int patches_modified = 0;

--- a/source/config.h
+++ b/source/config.h
@@ -9,6 +9,7 @@ struct config_file {
     uint8_t firm_console;
     uint32_t emunand_location;
     unsigned int autoboot_enabled: 1;
+    unsigned int silent_boot: 1;
     unsigned int cake_count;
     char cake_list[][_MAX_LFN + 1];
 } __attribute__((packed));

--- a/source/draw.c
+++ b/source/draw.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include "memfuncs.h"
 #include "font.h"
+#include "config.h"
 
 static struct framebuffers {
     uint8_t *top_left;
@@ -150,6 +151,10 @@ int draw_string(const enum screen screen, const char *string, const unsigned int
 
 void print(const char *string)
 {
+    // If silent boot is enabled, don't output.
+    if (config->silent_boot)
+        return;
+
     struct buffer_select select = {0};
     set_buffers(print_screen, &select);
 

--- a/source/fs.c
+++ b/source/fs.c
@@ -12,7 +12,6 @@ int mount_sd()
         print("Failed to mount SD card!");
         return 1;
     }
-    print("Mounted SD card");
     return 0;
 }
 

--- a/source/main.c
+++ b/source/main.c
@@ -42,9 +42,11 @@ void menu_select_patches()
 void menu_toggle()
 {
     char *options[] = {"Enable autoboot (Press L to enter the menu)",
-                       "Force saving patched firmware"};
+                       "Force saving patched firmware",
+                       "Silence debug output"};
     int preselected[] = {config->autoboot_enabled,
-                         save_firm};
+                         save_firm,
+                         config->silent_boot};
 
     int *result = draw_selection_menu("Toggleable options", sizeof(options) / sizeof(char *),
                                       options, preselected);
@@ -52,6 +54,7 @@ void menu_toggle()
     // Apply the options
     config->autoboot_enabled = result[0];
     save_firm = result[1];
+    config->silent_boot = result[2]; // This doesn't change patches.
     patches_modified |= preselected[0] ? 0 : result[0];
     patches_modified |= preselected[1] ? 0 : result[1];
 }


### PR DESCRIPTION
This silences the debug output in print, adds an option and bumps the config version. I was an idiot earlier, sorry about that. As a result, this is much smaller than the previous (incorrect) implementation.

Also, this should close #44.
